### PR TITLE
Fix behavior when a given userIdent tries to obtain a second lock on a record

### DIFF
--- a/lib/Doctrine/Locking/Manager/Pessimistic.php
+++ b/lib/Doctrine/Locking/Manager/Pessimistic.php
@@ -141,8 +141,8 @@ class Doctrine_Locking_Manager_Pessimistic
             }
 
             if ( ! $gotLock) {
-                $lockingKey = $this->_getUserIdent($objectType, $key);
-                if ($lockingKey !== null && $lockingKey == $userIdent) {
+                $lockOwner = $this->getLockOwner($record);
+                if ($lockOwner !== null && $lockOwner == $userIdent) {
                     $gotLock = true; // The requesting user already has a lock
                     // Update timestamp
                     $stmt = $dbh->prepare('UPDATE ' . $this->_lockTable 
@@ -153,7 +153,7 @@ class Doctrine_Locking_Manager_Pessimistic
                     $stmt->bindParam(':ts', $time);
                     $stmt->bindParam(':object_type', $objectType);
                     $stmt->bindParam(':object_key', $objectKey);
-                    $stmt->bindParam(':user_ident', $lockingKey);
+                    $stmt->bindParam(':user_ident', $lockOwner);
                     $stmt->execute();
                 }
             }

--- a/tests/PessimisticLockingTestCase.php
+++ b/tests/PessimisticLockingTestCase.php
@@ -91,6 +91,10 @@ class Doctrine_PessimisticLocking_TestCase extends Doctrine_UnitTestCase
         $gotLock = $this->lockingManager->getLock($entries[1], 'michael');
         $this->assertTrue($gotLock);
 
+        // Getting a lock using the same userIdent that already has the lock should succeed
+        $gotLock = $this->lockingManager->getLock($entries[1], 'michael');
+        $this->assertTrue($gotLock);
+
         // Test release lock
         $released = $this->lockingManager->releaseLock($entries[0], 'romanb');
         $this->assertTrue($released);


### PR DESCRIPTION
Earlier we fixed Doctrine_Locking_Manager_Pessimistic to object_keys of the record's ID rather than the string 'id'. However, when trying to obtain a second lock, it was skipping the getLockOwner() method, and therefore using the string 'id'. This fixes that behavior so a given userIdent can obtain a lock multiple times on a record.